### PR TITLE
Expose querycsv package

### DIFF
--- a/querycsv/querycsv.py
+++ b/querycsv/querycsv.py
@@ -1,45 +1,47 @@
-#! /usr/bin/python
-# querycsv.py
-#
-# Purpose:
-#   Execute SQL (conceptually, a SELECT statement) on an input file, and
-#    write the results to an output file.
-#
-# Author(s):
-#    R. Dreas Nielsen (RDN)
-#
-# Copyright and license:
-#    Copyright (c) 2008, R.Dreas Nielsen
-#    This program is free software: you can redistribute it and/or modify
-#   it under the terms of the GNU General Public License as published by
-#   the Free Software Foundation, either version 3 of the License, or
-#   (at your option) any later version.
-#   This program is distributed in the hope that it will be useful,
-#   but WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#   GNU General Public License for more details.
-#   The GNU General Public License is available at <http://www.gnu.org/licenses/>
-#
-# Notes:
-#    1. The input files must be in a delimited format, such as a CSV file.
-#    2. The first line of each input file must contain column names.
-#    3. Default output is to the console in a readable format.  Output to
-#        a file is in CSV format.
-#
-# History:
-#    Date        Revisions
-#   -------     ---------------
-#    2/17/2008    First version.  One CSV file input, output only to CSV.  RDN.
-#    2/19/2008    Began adding code to allow multiple input files, or an existing
-#                sqlite file, to allow a sqlite file to be preserved, and to
-#                default to console output rather than CSV output.  RDN.
-#    2/20/2008    Completed coding of revisions.  RDN.
-#    2/22/2008    Added 'conn.close()' to 'qsqlite()'.  Corrected order of arguments
-#                to 'qsqlite()' in 'main()'. RDN.
-#    2/23/2008    Added 'commit()' after copying data into the sqlite file; otherwise
-#                it is not preserved.  Added the option to execute SQL commands
-#                from a script file. RDN.
-#=====================================================================================
+#!/usr/bin/env python
+"""
+ querycsv.py
+
+ Purpose:
+   Execute SQL (conceptually, a SELECT statement) on an input file, and
+   write the results to an output file.
+
+ Author(s):
+   R. Dreas Nielsen (RDN)
+
+ Copyright and license:
+   Copyright (c) 2008, R.Dreas Nielsen
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   The GNU General Public License is available at
+   <http://www.gnu.org/licenses/>
+
+ Notes:
+   1. The input files must be in a delimited format, such as a CSV file.
+   2. The first line of each input file must contain column names.
+   3. Default output is to the console in a readable format.  Output to
+      a file is in CSV format.
+
+ History:
+   Date        Revisions
+   -------     ---------------
+   2/17/2008    First version.  One CSV file input, output only to CSV.  RDN.
+   2/19/2008    Began adding code to allow multiple input files, or an
+                existing sqlite file, to allow a sqlite file to be preserved,
+                and to default to console output rather than CSV output.  RDN.
+   2/20/2008    Completed coding of revisions.  RDN.
+   2/22/2008    Added 'conn.close()' to 'qsqlite()'.  Corrected order of
+                arguments to 'qsqlite()' in 'main()'. RDN.
+   2/23/2008    Added 'commit()' after copying data into the sqlite file;
+                otherwise it is not preserved.  Added the option to execute
+                SQL commands from a script file. RDN.
+"""
 
 import sys
 import os.path
@@ -56,7 +58,8 @@ Syntax:
     querycsv [options] <SELECT_stmt or scriptfile_name>
 Options:
    -i <fname> Input CSV file name.
-              Multiple -i options can be used to specify more than one input file.
+              Multiple -i options can be used to specify more than one input
+              file.
    -u <fname> Use the specified sqlite file for input.
               Options -i, -f, and -k are ignored if -u is specified
    -o <fname> Send output to the named CSV file.
@@ -88,15 +91,18 @@ def quote_str(str):
         return "'%s'" % str.replace("'", "''")
     return str
 
+
 def quote_list(l):
     return [quote_str(x) for x in l]
+
 
 def quote_list_as_str(l):
     return ",".join(quote_list(l))
 
-## pp() function by Aaron Watters, posted to gadfly-rdbms@egroups.com 1999-01-18
-## modified version
-## Taken from sqliteplus.py by Florent Xicluna
+
+# pp() function by Aaron Watters posted to gadfly-rdbms@egroups.com 1999-01-18
+# modified version
+# Taken from sqliteplus.py by Florent Xicluna
 def pp(cursor):
     rows = cursor.fetchall()
     desc = cursor.description
@@ -105,20 +111,22 @@ def pp(cursor):
     names = [d[0] for d in desc]
     rcols = range(len(desc))
     rrows = range(len(rows))
-    maxen = [max(0,len(names[j]),*(len(str(rows[i][j]))
+    maxen = [max(0, len(names[j]), *(len(str(rows[i][j]))
              for i in rrows)) for j in rcols]
-    names = ' '+' | '.join(
-            [names[j].ljust(maxen[j]) for j in rcols])
-    sep = '='*(reduce(lambda x,y:x+y, maxen) + 3*len(desc) - 1)
-    rows = [names, sep] + [' '+' | '.join(
-            [str(rows[i][j]).ljust(maxen[j])
-            for j in rcols] ) for i in rrows]
-    return '\n'.join(rows)+(
-           len(rows)==2 and '\n no row selected\n' or '\n')
+    names = ' '+' | '.join([names[j].ljust(maxen[j]) for j in rcols])
+    sep = '=' * (reduce(lambda x, y: x + y, maxen) + 3 * len(desc) - 1)
+    rows = [names, sep] + [' '+' | '.join([str(rows[i][j]).ljust(maxen[j])
+                                           for j in rcols])
+                           for i in rrows]
+    return '\n'.join(rows) + (
+        len(rows) == 2 and '\n no row selected\n' or '\n')
 
-def read_sqlfile( fn ):
-    """Open the text file with the specified name, read it, and return a list of
-    the SQL statements it contains."""
+
+def read_sqlfile(fn):
+    """
+    Open the text file with the specified name, read it, and return a list of
+    the SQL statements it contains.
+    """
     # Currently (11/11/2007) this routine knows only two things about SQL:
     #    1. Lines that start with "--" are comments.
     #    2. Lines that end with ";" terminate a SQL statement.
@@ -134,15 +142,18 @@ def read_sqlfile( fn ):
                 currcmd = ''
     return sqllist
 
-def execsql( db, sqllist, outfile=None ):
-    """Arguments:
-        'db' is a database object that conforms to the Python db API (intended to a sqlite3 database connection).
-        'sqllist' is a list of SQL statements, to be executed in order.
-        'outfile' is the name of a CSV file in which to dump the results of the last command."""
+
+def execsql(db, sqllist, outfile=None):
+    """
+    db: Database object that conforms to the Python DB API.
+    sqllist: List of SQL statements, to be executed in order.
+    outfile: Name of CSV file in which to dump the results of the last command.
+    """
     curs = db.cursor()
-    for i in range(len(sqllist)-1):
+    for i in range(len(sqllist) - 1):
         curs.execute(sqllist[i])
-    qsqldb( db, sqllist[ len(sqllist)-1 ], outfile )
+    qsqldb(db, sqllist[len(sqllist) - 1], outfile)
+
 
 def csv_to_sqldb(sqldb, infilename, table_name):
     dialect = csv.Sniffer().sniff(open(infilename, "rt").readline())
@@ -155,12 +166,17 @@ def csv_to_sqldb(sqldb, infilename, table_name):
         pass
     sqldb.execute("create table %s (%s);" % (table_name, colstr))
     for l in inf:
-        sql = "insert into %s values (%s);" % (table_name, quote_list_as_str(l))
+        vals = quote_list_as_str(l)
+        sql = "insert into %s values (%s);" % (table_name, vals)
         sqldb.execute(sql)
     sqldb.commit()
 
-def qsqldb( sqldb, sql_cmd, outfilename=None  ):
-    """Run a SQL command on the specified (open) sqlite3 database, and write out the output."""
+
+def qsqldb(sqldb, sql_cmd, outfilename=None):
+    """
+    Run a SQL command on the specified (open) sqlite3 database,
+    and write the output.
+    """
     #
     # Create the output file if specified
     if outfilename:
@@ -174,7 +190,7 @@ def qsqldb( sqldb, sql_cmd, outfilename=None  ):
     # Write output to file or console
     if outfilename:
         datarows = curs.fetchall()
-        headers = [ item[0] for item in curs.description ]
+        headers = [item[0] for item in curs.description]
         csvout.writerow(headers)
         for row in datarows:
             csvout.writerow(list(row))
@@ -182,18 +198,25 @@ def qsqldb( sqldb, sql_cmd, outfilename=None  ):
     else:
         print pp(curs)
 
-def qsqlite( sql_cmd, sqlfilename=None, outfilename=None ):
-    """Run a SQL command on a sqlite database in the specified file (or in memory if sqlfilename is None)."""
-    if sqlfilename == None:
+
+def qsqlite(sql_cmd, sqlfilename=None, outfilename=None):
+    """
+    Run a SQL command on a sqlite database in the specified file
+    (or in memory if sqlfilename is None).
+    """
+    if not sqlfilename:
         conn = sqlite3.connect(":memory:")
     else:
         conn = sqlite3.connect(sqlfilename)
-    qsqldb( conn, sql_cmd, outfilename  )
+    qsqldb(conn, sql_cmd, outfilename)
     conn.close()
 
+
 def qcsv(infilenames, outfilename, file_db, keep_db, sql_cmd):
-    """Query the listed CSV files, optionally writing the output to a sqlite file on disk."""
-    #
+    """
+    Query the listed CSV files, optionally writing the output to a
+    sqlite file on disk.
+    """
     # Create a sqlite file, if specified
     if file_db:
         try:
@@ -203,16 +226,16 @@ def qcsv(infilenames, outfilename, file_db, keep_db, sql_cmd):
         conn = sqlite3.connect(file_db)
     else:
         conn = sqlite3.connect(":memory:")
-    #
+
     # Move data from input CSV files into sqlite
     for csvfile in infilenames:
         inhead, intail = os.path.split(csvfile)
         tablename = os.path.splitext(intail)[0]
         csv_to_sqldb(conn, csvfile, tablename)
-    #
+
     # Execute the SQL
-    qsqldb( conn, sql_cmd, outfilename )
-    #
+    qsqldb(conn, sql_cmd, outfilename)
+
     # Clean up.
     conn.close()
     if file_db and not keep_db:
@@ -221,18 +244,26 @@ def qcsv(infilenames, outfilename, file_db, keep_db, sql_cmd):
         except:
             pass
 
-def qsqlite_script( scriptfile, sqlfilename=None, outfilename=None ):
-    """Run a script of SQL commands on a sqlite database in the specified file (or in memory if sqlfilename is None)."""
-    if sqlfilename == None:
+
+def qsqlite_script(scriptfile, sqlfilename=None, outfilename=None):
+    """
+    Run a script of SQL commands on a sqlite database in the specified
+    file (or in memory if sqlfilename is None).
+    """
+    if not sqlfilename:
         conn = sqlite3.connect(":memory:")
     else:
         conn = sqlite3.connect(sqlfilename)
     cmds = read_sqlfile(scriptfile)
-    execsql( conn, cmds, outfilename )
+    execsql(conn, cmds, outfilename)
     conn.close()
 
+
 def qcsv_script(infilenames, outfilename, file_db, keep_db, scriptfile):
-    """Query the listed CSV files, optionally writing the output to a sqlite file on disk."""
+    """
+    Query the listed CSV files, optionally writing the output to a sqlite
+    file on disk.
+    """
     #
     # Create a sqlite file, if specified
     if file_db:
@@ -243,17 +274,17 @@ def qcsv_script(infilenames, outfilename, file_db, keep_db, scriptfile):
         conn = sqlite3.connect(file_db)
     else:
         conn = sqlite3.connect(":memory:")
-    #
+
     # Move data from input CSV files into sqlite
     for csvfile in infilenames:
         inhead, intail = os.path.split(csvfile)
         tablename = os.path.splitext(intail)[0]
         csv_to_sqldb(conn, csvfile, tablename)
-    #
+
     # Execute the SQL
     cmds = read_sqlfile(scriptfile)
-    execsql( conn, cmds, outfilename )
-    #
+    execsql(conn, cmds, outfilename)
+
     # Clean up.
     conn.close()
     if file_db and not keep_db:
@@ -264,42 +295,44 @@ def qcsv_script(infilenames, outfilename, file_db, keep_db, scriptfile):
 
 
 def print_help():
-    print "querycsv %s %s -- Executes SQL on a delimited text file." % (_version, _vdate)
+    print "querycsv %s %s -- Executes SQL on a delimited text file." % (
+        _version, _vdate)
     print __help_msg
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     optlist, arglist = getopt.getopt(sys.argv[1:], "i:u:o:f:khs")
-    if len(arglist) == 0 or '-h' in [ o[0] for o in optlist ]:
+    if len(arglist) == 0 or '-h' in [o[0] for o in optlist]:
         print_help()
         sys.exit(0)
     sqlcmd = " ".join(arglist)
     outfile = None
-    if '-o' in [ o[0] for o in optlist ]:
-        optvals = [ o[1] for o in optlist if o[0]=='-o' ]
+    if '-o' in [o[0] for o in optlist]:
+        optvals = [o[1] for o in optlist if o[0] == '-o']
         if len(optvals) > 0:
             outfile = optvals[0]
     usefile = None
-    if '-u' in [ o[0] for o in optlist ]:
-        optvals = [ o[1] for o in optlist if o[0]=='-u' ]
+    if '-u' in [o[0] for o in optlist]:
+        optvals = [o[1] for o in optlist if o[0] == '-u']
         if len(optvals) > 0:
             usefile = optvals[0]
-    execscript = '-s' in [ o[0] for o in optlist ]
+    execscript = '-s' in [o[0] for o in optlist]
     if usefile:
         if execscript:
-            qsqlite_script( sqlcmd, usefile, outfile )
+            qsqlite_script(sqlcmd, usefile, outfile)
             # 'sqlcmd' should actually be the script file name.
         else:
-            qsqlite( sqlcmd, usefile, outfile )
+            qsqlite(sqlcmd, usefile, outfile)
     else:
         file_db = None
-        if '-f' in [ o[0] for o in optlist ]:
-            optvals = [ o[1] for o in optlist if o[0]=='-f' ]
+        if '-f' in [o[0] for o in optlist]:
+            optvals = [o[1] for o in optlist if o[0] == '-f']
             if len(optvals) > 0:
                 file_db = optvals[0]
-        keep_db = '-k' in [ o[0] for o in optlist ]
+        keep_db = '-k' in [o[0] for o in optlist]
         csvfiles = []
-        if '-i' in [ o[0] for o in optlist ]:
-            csvfiles = [ o[1] for o in optlist if o[0]=='-i' ]
+        if '-i' in [o[0] for o in optlist]:
+            csvfiles = [o[1] for o in optlist if o[0] == '-i']
         if len(csvfiles) > 0:
             if execscript:
                 qcsv_script(csvfiles, outfile, file_db, keep_db, sqlcmd)

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,25 @@
 from distutils.core import setup
 
 setup(name='querycsv',
-    version='0.3.0.0',
-    description="Execute SQL code against data contained in one or more comma-separated-value (CSV) files.",
-    author='Dreas Nielsen',
-    author_email='dreas.nielsen@gmail.com',
-    url='none',
-    scripts=['querycsv/querycsv.py'],
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console',
-        'Intended Audience :: End Users/Desktop',
-        'License :: OSI Approved :: GNU General Public License (GPL)',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Topic :: Text Processing :: General',
-        'Topic :: Office/Business'
-        ],
-    long_description="""``querycsv.py`` is a Python module and program
+      version='0.3.0.0',
+      description="Execute SQL code against data contained in one or more"
+                  " comma-separated-value (CSV) files.",
+      author='Dreas Nielsen',
+      author_email='dreas.nielsen@gmail.com',
+      url='none',
+      scripts=['querycsv/querycsv.py'],
+      classifiers=[
+          'Development Status :: 5 - Production/Stable',
+          'Environment :: Console',
+          'Intended Audience :: End Users/Desktop',
+          'License :: OSI Approved :: GNU General Public License (GPL)',
+          'Natural Language :: English',
+          'Operating System :: OS Independent',
+          'Topic :: Text Processing :: General',
+          'Topic :: Office/Business'
+      ],
+      long_description="""``querycsv.py`` is a Python module and program
 that executes SQL code against data contained in one or more
 comma-separated-value (CSV) files. The output of the SQL query will be
 displayed on the console by default, but may be saved in a new CSV file.
-"""
-    )
+""")

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,13 @@ from distutils.core import setup
 
 setup(name='querycsv',
       version='0.3.0.0',
-      description="Execute SQL code against data contained in one or more"
-                  " comma-separated-value (CSV) files.",
+      description="Execute SQL code against data contained in one or more "
+                  "comma-separated-value (CSV) files.",
       author='Dreas Nielsen',
       author_email='dreas.nielsen@gmail.com',
       url='none',
       scripts=['querycsv/querycsv.py'],
+      packages=['querycsv'],
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Console',


### PR DESCRIPTION
The API has been exposed as a package so you should now be able to do something like this:

``` python
#!/usr/bin/env python
from querycsv.querycsv import query_csv

rows = query_csv('select * from result', ['result.csv'])
for row in rows:
    print(row)
```

Fixes #2
