### PR TITLE
Fix bugs and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ docs/_build/
 *~
 *.swp
 
+test_files/

--- a/querycsv/querycsv.py
+++ b/querycsv/querycsv.py
@@ -50,11 +50,9 @@ VERSION = "3.1.2"
 # Modified version taken from sqliteplus.py by Florent Xicluna
 def pretty_print(rows, fp):
     headers = rows.pop(0)
+    rows = [[unicode(col) for col in row] for row in rows]
 
     rcols = range(len(headers))
-    rrows = range(len(rows))
-
-    rows = [[unicode(col) for col in row] for row in rows]
 
     colwidth = [max(0, len(headers[i])) for i in xrange(len(headers))]
     for y in xrange(len(rows)):
@@ -145,7 +143,7 @@ def table_exists(conn, table_name):
     try:
         conn.execute('select 1 from {0}'.format(table_name))
         return True
-    except sqlite3.OperationalError as ex:
+    except sqlite3.OperationalError:
         return False
 
 

--- a/querycsv/querycsv.py
+++ b/querycsv/querycsv.py
@@ -1,46 +1,33 @@
 #!/usr/bin/env python
 """
- querycsv.py
+Executes SQL on a delimited text file.
 
- Purpose:
-   Execute SQL (conceptually, a SELECT statement) on an input file, and
-   write the results to an output file.
-
- Author(s):
-   R. Dreas Nielsen (RDN)
-
- Copyright and license:
-   Copyright (c) 2008, R.Dreas Nielsen
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-   The GNU General Public License is available at
-   <http://www.gnu.org/licenses/>
-
- Notes:
-   1. The input files must be in a delimited format, such as a CSV file.
-   2. The first line of each input file must contain column names.
-   3. Default output is to the console in a readable format.  Output to
-      a file is in CSV format.
-
- History:
-   Date        Revisions
-   -------     ---------------
-   2/17/2008    First version.  One CSV file input, output only to CSV.  RDN.
-   2/19/2008    Began adding code to allow multiple input files, or an
-                existing sqlite file, to allow a sqlite file to be preserved,
-                and to default to console output rather than CSV output.  RDN.
-   2/20/2008    Completed coding of revisions.  RDN.
-   2/22/2008    Added 'conn.close()' to 'qsqlite()'.  Corrected order of
-                arguments to 'qsqlite()' in 'main()'. RDN.
-   2/23/2008    Added 'commit()' after copying data into the sqlite file;
-                otherwise it is not preserved.  Added the option to execute
-                SQL commands from a script file. RDN.
+Copyright (c) 2008, R.Dreas Nielsen
+Licensed under the GNU General Public License version 3.
+Syntax:
+    querycsv -i <csv file>... [-o <fname>] [-f <sqlite file>]
+        (-s <fname>|<SELECT stmt>)
+    querycsv -u <sqlite file> [-o <fname>] (-s <fname>|<SELECT stmt>)
+Options:
+   -i <fname> Input CSV file name.
+              Multiple -i options can be used to specify more than one input
+              file.
+   -u <fname> Use the specified sqlite file for input.
+              Options -i and -f, are ignored if -u is specified
+   -o <fname> Send output to the named CSV file.
+   -s <fname> Execute a SQL script from the file given as the argument.
+              Output will be displayed from the last SQL command in
+              the script.
+   -f <fname> Use a sqlite file instead of memory for intermediate storage.
+   -h         Print this help and exit.
+Notes:
+   1. Table names used in the SQL should match the input CSV file names,
+      without the ".csv" extension.
+   2. When multiple input files or an existing sqlite file are used,
+      the SQL can contain JOIN expressions.
+   3. When a SQL script file is used instead of a single SQL command on
+      the command line, only the output of the last command will be
+      displayed.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
@@ -194,33 +181,7 @@ def query_csv_file(scriptfile, *args, **kwargs):
 
 
 def print_help():
-    print("""querycsv {0} -- Executes SQL on a delimited text file.
-Copyright (c) 2008, R.Dreas Nielsen
-Licensed under the GNU General Public License version 3.
-Syntax:
-    querycsv -i <csv file>... [-o <fname>] [-f <sqlite file>]
-        (-s <fname>|<SELECT stmt>)
-    querycsv -u <sqlite file> [-o <fname>] (-s <fname>|<SELECT stmt>)
-Options:
-   -i <fname> Input CSV file name.
-              Multiple -i options can be used to specify more than one input
-              file.
-   -u <fname> Use the specified sqlite file for input.
-              Options -i and -f, are ignored if -u is specified
-   -o <fname> Send output to the named CSV file.
-   -s <fname> Execute a SQL script from the file given as the argument.
-              Output will be displayed from the last SQL command in
-              the script.
-   -f <fname> Use a sqlite file instead of memory for intermediate storage.
-   -h         Print this help and exit.
-Notes:
-   1. Table names used in the SQL should match the input CSV file names,
-      without the ".csv" extension.
-   2. When multiple input files or an existing sqlite file are used,
-      the SQL can contain JOIN expressions.
-   3. When a SQL script file is used instead of a single SQL command on
-      the command line, only the output of the last command will be
-      displayed.""".format(VERSION))
+    print(__doc__.strip())
 
 
 def main():

--- a/querycsv/querycsv.py
+++ b/querycsv/querycsv.py
@@ -97,10 +97,11 @@ def read_sqlfile(filename):
     return sqlcmds
 
 
-def commands(cmds):
-    if isinstance(cmds, (str, unicode)):
-        return [cmds]
-    return cmds
+def as_list(item):
+    """Wrap `item` in a list if it isn't already one."""
+    if isinstance(item, (str, unicode)):
+        return [item]
+    return item
 
 
 def csv_to_sqldb(db, filename, table_name):
@@ -142,7 +143,7 @@ def query_sqlite(sqlcmd, sqlfilename=None):
     """
     database = sqlfilename if sqlfilename else ':memory:'
     with sqlite3.connect(database) as conn:
-        return execute_sql(conn, commands(sqlcmd))
+        return execute_sql(conn, as_list(sqlcmd))
 
 
 def query_sqlite_file(scriptfile, *args, **kwargs):
@@ -166,11 +167,10 @@ def query_csv(sqlcmd, infilenames, file_db=None):
             head, tail = os.path.split(csvfile)
             tablename = os.path.splitext(tail)[0]
             csv_to_sqldb(conn, csvfile, tablename)
-
-            # Execute the SQL
-            results = execute_sql(conn, commands(sqlcmd))
-
+        results = execute_sql(conn, as_list(sqlcmd))
     return results
+
+
 
 
 def query_csv_file(scriptfile, *args, **kwargs):

--- a/querycsv/querycsv.py
+++ b/querycsv/querycsv.py
@@ -8,6 +8,7 @@ Syntax:
     querycsv -i <csv file>... [-o <fname>] [-f <sqlite file>]
         (-s <fname>|<SELECT stmt>)
     querycsv -u <sqlite file> [-o <fname>] (-s <fname>|<SELECT stmt>)
+    querycsv (-h|-V)
 Options:
    -i <fname> Input CSV file name.
               Multiple -i options can be used to specify more than one input
@@ -20,6 +21,7 @@ Options:
               the script.
    -f <fname> Use a sqlite file instead of memory for intermediate storage.
    -h         Print this help and exit.
+   -V         Print the version number.
 Notes:
    1. Table names used in the SQL should match the input CSV file names,
       without the ".csv" extension.
@@ -185,8 +187,12 @@ def print_help():
 
 
 def main():
-    optlist, arglist = getopt.getopt(sys.argv[1:], "i:u:o:f:hs")
+    optlist, arglist = getopt.getopt(sys.argv[1:], "i:u:o:f:Vhs")
     flags = dict(optlist)
+
+    if '-V' in flags:
+        print(VERSION)
+        sys.exit(0)
 
     if len(arglist) == 0 or '-h' in flags:
         print_help()

--- a/querycsv/querycsv.py
+++ b/querycsv/querycsv.py
@@ -53,11 +53,16 @@ def pretty_print(rows, fp):
 
     rcols = range(len(headers))
     rrows = range(len(rows))
-    colwidth = [max(0, len(headers[j]),
-                    *(len(rows[i][j]) for i in rrows)) for j in rcols]
+
+    rows = [[unicode(col) for col in row] for row in rows]
+
+    colwidth = [max(0, len(headers[i])) for i in xrange(len(headers))]
+    for y in xrange(len(rows)):
+        for x in xrange(len(headers)):
+            colwidth[x] = max(colwidth[x], len(rows[y][x]))
 
     # Header
-    fp.write(' ' + ' | '.join([headers[i].ljust(colwidth[i])
+    fp.write(' ' + ' | '.join([unicode(headers[i]).ljust(colwidth[i])
                                for i in rcols]) + '\n')
 
     # Seperator

--- a/querycsv/tests.py
+++ b/querycsv/tests.py
@@ -7,9 +7,11 @@ import csv
 import os.path
 import unittest
 
+from StringIO import StringIO
+
 from .querycsv import (query_csv, query_csv_file,
                        query_sqlite, query_sqlite_file,
-                       import_csv)
+                       import_csv, pretty_print)
 
 TEST_DIR = 'test_files'
 
@@ -156,6 +158,17 @@ class TestQueryFunctions(unittest.TestCase):
             4, 5, 6
             """)
 
+    def test_pretty_print1(self):
+        fp = StringIO()
+        results = query_csv('select * from foo', self.foo)
+        pretty_print(results, fp)
+        self.assertEqual(fp.getvalue(), ' a | b | c\n===========\n 1 | 2 | 3\n')
+
+    def test_pretty_print2(self):
+        fp = StringIO()
+        results = query_csv('select count(*) from foo', self.foo)
+        pretty_print(results, fp)
+        self.assertEqual(fp.getvalue(), ' count(*)\n==========\n 1       \n')
 
 if __name__ == '__main__':
     unittest.main()

--- a/querycsv/tests.py
+++ b/querycsv/tests.py
@@ -10,8 +10,8 @@ import unittest
 from StringIO import StringIO
 
 from .querycsv import (query_csv, query_csv_file,
-                       query_sqlite, query_sqlite_file,
-                       import_csv, pretty_print)
+                       query_sqlite, import_csv,
+                       pretty_print)
 
 TEST_DIR = 'test_files'
 
@@ -162,13 +162,15 @@ class TestQueryFunctions(unittest.TestCase):
         fp = StringIO()
         results = query_csv('select * from foo', self.foo)
         pretty_print(results, fp)
-        self.assertEqual(fp.getvalue(), ' a | b | c\n===========\n 1 | 2 | 3\n')
+        self.assertEqual(fp.getvalue(),
+                         ' a | b | c\n===========\n 1 | 2 | 3\n')
 
     def test_pretty_print2(self):
         fp = StringIO()
         results = query_csv('select count(*) from foo', self.foo)
         pretty_print(results, fp)
-        self.assertEqual(fp.getvalue(), ' count(*)\n==========\n 1       \n')
+        self.assertEqual(fp.getvalue(),
+                         ' count(*)\n==========\n 1       \n')
 
 if __name__ == '__main__':
     unittest.main()

--- a/querycsv/tests.py
+++ b/querycsv/tests.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import csv
+import os.path
+import unittest
+
+from .querycsv import (query_csv, query_csv_file,
+                       query_sqlite, query_sqlite_file,
+                       import_csv)
+
+TEST_DIR = 'test_files'
+
+
+def testfile(filename):
+    return os.path.join(TEST_DIR, filename)
+
+
+def create_csv(filename, content):
+    create_test_folder()
+    with open(filename, 'wb') as f:
+        writer = csv.writer(f)
+        rows = to_csv_rows(content)
+        writer.writerows(rows)
+
+
+def create_file(filename, content):
+    create_test_folder()
+    with open(filename, 'wb') as f:
+        f.write(content)
+
+
+def create_test_folder():
+    try:
+        os.makedirs(TEST_DIR)
+    except OSError:
+        pass
+
+
+def to_csv_rows(content):
+    return [[col.strip() for col in row.split(',')]
+            for row in content.strip().split('\n')]
+
+
+class TestQueryFunctions(unittest.TestCase):
+
+    def setUp(self):
+        self.db = testfile('db.sqlite3')
+        self.foo = testfile('foo.csv')
+        self.bar = testfile('bar.csv')
+        create_csv(self.foo, """
+            a, b, c
+            1, 2, 3
+            """)
+        create_csv(self.bar, """
+            a, b, c
+            4, 5, 6
+            """)
+
+    def tearDown(self):
+        if os.path.exists(self.db):
+            os.unlink(self.db)
+
+    def assertMatch(self, results, content):
+        rows = to_csv_rows(content)
+        self.assertEqual(len(results), len(rows))
+        for y in xrange(0, len(rows)):
+            rowA = rows[y]
+            rowB = results[y]
+            self.assertEqual(len(rowA), len(rowB))
+            for x in xrange(0, len(rowA)):
+                a = str(rowA[x])
+                b = str(rowB[x])
+                self.assertEqual(a, b)
+
+    def test_query_csv1(self):
+        """Test query_csv with single table."""
+        results = query_csv('select * from foo', self.foo)
+        self.assertMatch(results, """
+            a, b, c
+            1, 2, 3
+            """)
+
+    def test_query_csv2(self):
+        """Test query_csv with multiple tables."""
+        results = query_csv('select * from foo union all '
+                            'select * from bar',
+                            [self.foo, self.bar])
+        self.assertMatch(results, """
+            a, b, c
+            1, 2, 3
+            4, 5, 6
+            """)
+
+    def test_query_csv3(self):
+        """Test query_csv with multiple commands."""
+        results = query_csv(['update foo set a=(a+b+c)',
+                             'select a from foo'],
+                            self.foo)
+        self.assertMatch(results, """
+            a
+            6
+            """)
+
+    def test_query_csv_file(self):
+        """Test query_csv_file."""
+        query1 = testfile('query1.sql')
+        create_file(query1, 'update foo set a=(a+b+c);\n'
+                            'select a from foo;')
+        results = query_csv_file(query1, self.foo)
+        self.assertMatch(results, """
+            a
+            6
+            """)
+
+    def test_query_sqlite(self):
+        """Test query_sqlite."""
+        import_csv(self.db, self.foo, table_name='foo2')
+        results = query_sqlite('select * from foo2', self.db)
+        self.assertMatch(results, """
+            a, b, c
+            1, 2, 3
+            """)
+
+    def test_query_sqlite_overwrite1(self):
+        """Test that tables are NOT overwritten when overwrite=False."""
+        import_csv(self.db, self.foo, table_name='tmp')
+        results = query_sqlite('select * from tmp', self.db)
+        self.assertMatch(results, """
+            a, b, c
+            1, 2, 3
+            """)
+
+        import_csv(self.db, self.bar, table_name='tmp', overwrite=False)
+        results = query_sqlite('select * from tmp', self.db)
+        self.assertMatch(results, """
+            a, b, c
+            1, 2, 3
+            """)
+
+    def test_query_sqlite_overwrite2(self):
+        """Test that tables ARE overwritten when overwrite=True."""
+        import_csv(self.db, self.foo, table_name='tmp')
+        results = query_sqlite('select * from tmp', self.db)
+        self.assertMatch(results, """
+            a, b, c
+            1, 2, 3
+            """)
+
+        import_csv(self.db, self.bar, table_name='tmp', overwrite=True)
+        results = query_sqlite('select * from tmp', self.db)
+        self.assertMatch(results, """
+            a, b, c
+            4, 5, 6
+            """)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The following changes have been made to the API:

**query_csv(sqlcmd, infilenames, file_db=None)**
- Can use single or multiple values for SQL commands and CSV file inputs.

``` python
query_csv('select * from foo', 'foo.csv')

query_csv(['update foo set a=a+1',
           'select * from foo cross join bar'], ['foo.csv', 'bar.csv'])
```

**import_csv(db, filename, table_name=None, overwrite=False)**

This function gives more control over importing CSV files directly into a datasource. Once CSV files have been imported into a SQLite database `query_sqlite` may be used instead of `query_csv`.
- CSV files are no longer re-imported if the associated table already exists in the datasource.

``` python
import_csv('db.sqlite', 'foo.csv')
# foo.csv is imported into db.sqlite
import_csv('db.sqlite', 'foo.csv')
# foo.csv is NOT re-imported
```

This behavior can be disabled with the `overwrite` flag.

``` python
import_csv('db.sqlite', 'foo.csv')
# foo.csv is imported into db.sqlite
import_csv('db.sqlite', 'foo.csv', overwrite=True)
# foo.csv IS re-imported
```
- Can now import a CSV with a different name.

``` python
import_csv('db.sqlite', 'foo.csv', table_name='bar')
# foo.csv is imported into a table named "bar"
```

Fixes #11 
Fixes #12 
Fixes #14
